### PR TITLE
Add capability to stream from Arlo cameras

### DIFF
--- a/ArloCameraSource.js
+++ b/ArloCameraSource.js
@@ -234,11 +234,11 @@ class ArloCameraSource extends EventEmitter {
         this.videoProcessor = config.videoProcessor || 'ffmpeg';
         this.videoDecoder = config.videoDecoder || '';
         this.videoEncoder = config.videoEncoder || 'libx264';
-        this.audioCodec = config.audioCodec || 'libfdk_aac';
-        this.packetsize = config.packetsize; // 188, 376, 1316
-        this.fps = config.maxFPS || 24;
+        this.audioCodec = config.audioEncoder || 'libfdk_aac';
+        this.packetsize = config.packetsize || 1316; //188, 376, 1316
+        this.fps = 24;
         this.maxBitrate = config.maxBitrate || 300;
-        this.additionalCommands = config.additionalCommands || '';
+        this.additionalCommands = (config.additionalCommands ? (' ' + config.additionalCommands) : '');
 
         let numberOfStreams = config.maxStreams || 2;
 
@@ -416,15 +416,15 @@ class ArloCameraSource extends EventEmitter {
                 if (sessionInfo) {
                     var width = 1280;
                     var height = 720;
-                    var fps = this.fps || 30;
+                    var fps = this.fps;
                     var vbitrate = 1500;
                     var abitrate = 32;
                     var asamplerate = 16;
                     var vDecoder = this.videoDecoder ? (' -c:v ' + this.videoDecoder) : '';
                     var vEncoder = this.videoEncoder;
                     var acodec = this.audioCodec;
-                    var packetsize = this.packetsize || 1316;
-                    var additionalCommandline = this.additionalCommandline;
+                    var packetsize = this.packetsize;
+                    var additionalCommandline = this.additionalCommands;
 
                     let videoInfo = request["video"];
                     if (videoInfo) {
@@ -464,8 +464,8 @@ class ArloCameraSource extends EventEmitter {
                     ' -pix_fmt yuv420p' +
                     ' -r ' + fps +
                     ' -f rawvideo' +
-                    //' ' + additionalCommandline +
                     ' -vf scale=' + width + ':' + height +
+                    additionalCommandline +
                     ' -b:v ' + vbitrate + 'k' +
                     ' -bufsize ' + vbitrate+ 'k' +
                     ' -maxrate '+ vbitrate + 'k' +

--- a/ArloCameraSource.js
+++ b/ArloCameraSource.js
@@ -234,7 +234,7 @@ class ArloCameraSource extends EventEmitter {
         this.videoProcessor = config.videoProcessor || 'ffmpeg';
         this.videoDecoder = config.videoDecoder || '';
         this.videoEncoder = config.videoEncoder || 'libx264';
-        this.audioCodec = config.audioEncoder || 'libfdk_aac';
+        this.audioCodec = config.audioEncoder || 'libopus';
         this.packetsize = config.packetsize || 1316; //188, 376, 1316
         this.fps = 24;
         this.maxBitrate = config.maxBitrate || 300;
@@ -263,12 +263,8 @@ class ArloCameraSource extends EventEmitter {
                 codecs: [
                     {
                         type: 'OPUS',
-                        samplerate: 24
-                    },
-                    {
-
-                        type: "AAC-eld",
-                        samplerate: 16
+                        samplerate: 24,
+                        comfort_noise: true
                     }
                 ]
             }
@@ -495,12 +491,11 @@ class ArloCameraSource extends EventEmitter {
                     // Audio
                     ffmpegCommand+= ' -map 0:0' +
                     ' -acodec ' + acodec +
-                    ' -profile:a aac_eld' +
                     ' -flags +global_header' +
                     ' -f null' +
                     ' -ar ' + asamplerate + 'k' +
                     ' -b:a ' + abitrate + 'k' +
-                    ' -bufsize ' + abitrate + 'k' +
+                    ' -bufsize ' + abitrate * 2 + 'k' +
                     ' -ac 1' +
                     ' -payload_type 110' +
                     ' -ssrc ' + audioSsrc +

--- a/ArloCameraSource.js
+++ b/ArloCameraSource.js
@@ -220,8 +220,6 @@ class ArloCameraSource extends EventEmitter {
         StreamController = hap.StreamController;
         UUIDGen = hap.uuid;
 
-        debug('Streaming config: %O', config);
-
         this.log = log;
         this.accessory = accessory;
         this.device = device;
@@ -238,7 +236,8 @@ class ArloCameraSource extends EventEmitter {
         this.packetsize = config.packetsize || 1316; //188, 376, 1316
         this.fps = 24;
         this.maxBitrate = config.maxBitrate || 300;
-        this.additionalCommands = (config.additionalCommands ? (' ' + config.additionalCommands) : '');
+        this.additionalVideoCommands = (config.additionalVideoCommands ? (' ' + config.additionalVideoCommands) : '');
+        this.additionalAudioCommands = (config.additionalAudioCommands ? (' ' + config.additionalAudioCommands) : '');
 
         let numberOfStreams = config.maxStreams || 2;
 
@@ -418,7 +417,8 @@ class ArloCameraSource extends EventEmitter {
                     var asamplerate = 16;
                     var acodec = this.audioCodec;
                     var packetsize = this.packetsize;
-                    var additionalCommandline = this.additionalCommands;
+                    var additionalVideoCommands = this.additionalVideoCommands;
+                    var additionalAudioCommands = this.additionalAudioCommands;
 
                     var vDecoder, vEncoder, scaleCommand;
 
@@ -434,7 +434,7 @@ class ArloCameraSource extends EventEmitter {
                             scaleCommand = '';
                             debug('No change to video stream size required');
                         } else {
-                            // Scale video, requiring video transcoding
+                            // Scale video requested, requiring video transcoding
                             vDecoder = this.videoDecoder ? (' -c:v ' + this.videoDecoder) : '';
                             vEncoder = this.videoEncoder;
                             scaleCommand = ' -vf scale=' + width + ':' + height;
@@ -444,6 +444,7 @@ class ArloCameraSource extends EventEmitter {
                         if (expectedFPS < fps) {
                             fps = expectedFPS;
                         }
+
                         if(videoInfo["max_bit_rate"] < vbitrate) {
                             vbitrate = videoInfo["max_bit_rate"];
                         }
@@ -474,7 +475,7 @@ class ArloCameraSource extends EventEmitter {
                     ' -r ' + fps +
                     ' -f rawvideo' +
                     scaleCommand +
-                    additionalCommandline + 
+                    additionalVideoCommands + 
                     ' -b:v ' + vbitrate + 'k' +
                     ' -bufsize ' + vbitrate+ 'k' +
                     ' -maxrate '+ vbitrate + 'k' +
@@ -491,6 +492,7 @@ class ArloCameraSource extends EventEmitter {
                     // Audio
                     ffmpegCommand+= ' -map 0:0' +
                     ' -acodec ' + acodec +
+                    additionalAudioCommands + 
                     ' -flags +global_header' +
                     ' -f null' +
                     ' -ar ' + asamplerate + 'k' +

--- a/ArloCameraSource.js
+++ b/ArloCameraSource.js
@@ -1,0 +1,558 @@
+/**
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 KhaosT
+   Modifications 2018 Charles Powell
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+**/
+
+const EventEmitter = require('events').EventEmitter;
+const debug = require('debug')('Homebridge-Arlo:CameraSource');
+const debugFFmpeg = require('debug')('ffmpeg');
+const Arlo = require('node-arlo');
+const crypto = require('crypto');
+const ip = require('ip');
+const spawn = require('child_process').spawn;
+
+let StreamController, UUIDGen;
+
+class ArloCameraSource extends EventEmitter {
+    constructor(log, accessory, device, hap, config) {
+        super();
+
+        StreamController = hap.StreamController;
+        UUIDGen = hap.uuid;
+
+        debug('Streaming config: %O', config);
+
+        this.log = log;
+        this.accessory = accessory;
+        this.device = device;
+        this.services = [];
+        this.pendingSessions = {};
+        this.ongoingSessions = {};
+        this.streamControllers = [];
+        this.lastSnapshot = null;
+
+        this.videoProcessor = config.videoProcessor || 'ffmpeg';
+        this.videoDecoder = config.videoDecoder || '';
+        this.videoEncoder = config.videoEncoder || 'libx264';
+        this.audioCodec = config.audioCodec || 'libfdk_aac';
+        this.packetsize = config.packetsize; // 188, 376, 1316
+        this.fps = config.maxFPS || 24;
+        this.maxBitrate = config.maxBitrate || 300;
+        this.additionalCommands = config.additionalCommands || '';
+
+        let numberOfStreams = config.maxStreams || 2;
+
+        let options = {
+            proxy: false, // Requires RTP/RTCP MUX Proxy
+            srtp: true, // Supports SRTP AES_CM_128_HMAC_SHA1_80 encryption
+            video: {
+                resolutions: [
+                    [1280, 720, 24],
+                    [1280, 720, 15],
+                    [640, 360, 24],
+                    [640, 360, 15],
+                    [320, 240, 24],
+                    [320, 240, 15]
+                ],
+                codec: {
+                    profiles: [0, 1, 2],    //[StreamController.VideoCodecParamProfileIDTypes.MAIN],
+                    levels: [0, 1, 2]       //[StreamController.VideoCodecParamLevelTypes.TYPE4_0]
+                }
+            },
+            audio: {
+                codecs: [
+                    {
+                        type: 'OPUS',
+                        samplerate: 24
+                    },
+                    {
+
+                        type: "AAC-eld",
+                        samplerate: 16
+                    }
+                ]
+            }
+        }
+
+        this._createStreamControllers(numberOfStreams, options);
+        debug('Generated Camera Controller');
+    }
+
+    handleCloseConnection(connectionID) {
+        this.streamControllers.forEach(function(controller) {
+            controller.handleCloseConnection(connectionID);
+        });
+    }
+
+    handleSnapshotRequest(request, callback) {
+        debug('Snapshot requested');
+        let now = Date.now();
+
+        if (this.lastSnapshot && now < this.lastSnapshot + 300000) {
+            this.log('Snapshot skipped: Camera %s [%s] - Next in %d secs', this.accessory.displayName, this.device.id, parseInt((this.lastSnapshot + 300000 - now) / 1000));
+            callback();
+            return;
+        }
+
+        this.log("Snapshot request: Camera %s [%s]", this.accessory.displayName, this.device.id);
+
+        this.device.getSnapshot(function(error, data) {
+            if (error) {
+                this.log(error);
+                callback();
+                return;
+            }
+
+            this.lastSnapshot = Date.now();
+
+            this.log("Snapshot confirmed: Camera %s [%s]", this.accessory.displayName, this.device.id);
+
+           this.device.once(Arlo.FF_SNAPSHOT, function(url) {
+                this.device.downloadSnapshot(url, function (data) {
+                    this.log("Snapshot downloaded: Camera %s [%s]", this.accessory.displayName, this.device.id);
+                    callback(undefined, data);
+                }.bind(this));
+            }.bind(this));
+        }.bind(this));
+    }
+
+    prepareStream(request, callback) {
+        debug('Prepare stream request');
+
+        var self = this;
+
+        this.device.getStream(function (streamURL) {
+            debug('Preparing stream for URL: %s',streamURL);
+            debug('Prepare Stream request: %O', request);
+
+            var sessionInfo = {};
+            let sessionID = request["sessionID"];
+            let targetAddress = request["targetAddress"];
+
+            sessionInfo["streamURL"] = streamURL;
+            sessionInfo["address"] = targetAddress;
+
+            var response = {};
+
+            let videoInfo = request["video"];
+            if (videoInfo) {
+                let targetPort = videoInfo["port"];
+                let srtp_key = videoInfo["srtp_key"];
+                let srtp_salt = videoInfo["srtp_salt"];
+
+                // SSRC is a 32 bit integer that is unique per stream
+                let ssrcSource = crypto.randomBytes(4);
+                ssrcSource[0] = 0;
+                let ssrc = ssrcSource.readInt32BE(0, true);
+
+                let videoResponse = {
+                    port: targetPort,
+                    ssrc: ssrc,
+                    srtp_key: srtp_key,
+                    srtp_salt: srtp_salt
+                };
+
+                response["video"] = videoResponse;
+                sessionInfo["video_port"] = targetPort;
+                sessionInfo["video_srtp"] = Buffer.concat([srtp_key, srtp_salt]);
+                sessionInfo["video_ssrc"] = ssrc;
+            }
+
+            let audioInfo = request["audio"];
+            if (audioInfo) {
+                let targetPort = audioInfo["port"];
+                let srtp_key = audioInfo["srtp_key"];
+                let srtp_salt = audioInfo["srtp_salt"];
+
+                // SSRC is a 32 bit integer that is unique per stream
+                let ssrcSource = crypto.randomBytes(4);
+                ssrcSource[0] = 0;
+                let ssrc = ssrcSource.readInt32BE(0, true);
+
+                let audioResp = {
+                    port: targetPort,
+                    ssrc: ssrc,
+                    srtp_key: srtp_key,
+                    srtp_salt: srtp_salt
+                };
+
+                response["audio"] = audioResp;
+
+                sessionInfo["audio_port"] = targetPort;
+                sessionInfo["audio_srtp"] = Buffer.concat([srtp_key, srtp_salt]);
+                sessionInfo["audio_ssrc"] = ssrc;
+            }
+
+            let currentAddress = ip.address();
+            var addressResp = {
+                address: currentAddress
+            };
+
+            if (ip.isV4Format(currentAddress)) {
+                addressResp["type"] = "v4";
+            } else {
+                addressResp["type"] = "v6";
+            }
+
+            response["address"] = addressResp;
+
+            self.pendingSessions[UUIDGen.unparse(sessionID)] = sessionInfo;
+
+            callback(response);
+        });
+    }
+
+    handleStreamRequest(request) {
+        debug('Handle Stream request: %O', request);
+
+        var sessionID = request["sessionID"];
+        var requestType = request["type"];
+        if (sessionID) {
+            let sessionIdentifier = UUIDGen.unparse(sessionID);
+
+            // Start streaming
+            if (requestType == "start") {
+                var sessionInfo = this.pendingSessions[sessionIdentifier];
+                if (sessionInfo) {
+                    var width = 1280;
+                    var height = 720;
+                    var fps = this.fps || 30;
+                    var vbitrate = 1500;
+                    var abitrate = 32;
+                    var asamplerate = 16;
+                    var vDecoder = this.videoDecoder ? (' -c:v ' + this.videoDecoder) : '';
+                    var vEncoder = this.videoEncoder;
+                    var acodec = this.audioCodec;
+                    var packetsize = this.packetsize || 1316;
+                    var additionalCommandline = this.additionalCommandline;
+
+                    let videoInfo = request["video"];
+                    if (videoInfo) {
+                        width = videoInfo["width"];
+                        height = videoInfo["height"];
+
+                        let expectedFPS = videoInfo["fps"];
+                        if (expectedFPS < fps) {
+                            fps = expectedFPS;
+                        }
+                        if(videoInfo["max_bit_rate"] < vbitrate) {
+                            vbitrate = videoInfo["max_bit_rate"];
+                        }
+                    }
+
+                    let audioInfo = request["audio"];
+                    if (audioInfo) {
+                        abitrate = audioInfo["max_bit_rate"];
+                        asamplerate = audioInfo["sample_rate"];
+                    }
+
+                    let streamURL = sessionInfo["streamURL"];
+
+                    let targetAddress = sessionInfo["address"];
+                    let targetVideoPort = sessionInfo["video_port"];
+                    let videoKey = sessionInfo["video_srtp"];
+                    let videoSsrc = sessionInfo["video_ssrc"];
+                    let targetAudioPort = sessionInfo["audio_port"];
+                    let audioKey = sessionInfo["audio_srtp"];
+                    let audioSsrc = sessionInfo["audio_ssrc"];
+
+                    // Video
+                    let ffmpegCommand = '-rtsp_transport tcp' +
+                    vDecoder + 
+                    ' -re -i ' + streamURL + ' -map 0:1' +
+                    ' -c:v ' + vEncoder +
+                    ' -pix_fmt yuv420p' +
+                    ' -r ' + fps +
+                    ' -f rawvideo' +
+                    //' ' + additionalCommandline +
+                    ' -vf scale=' + width + ':' + height +
+                    ' -b:v ' + vbitrate + 'k' +
+                    ' -bufsize ' + vbitrate+ 'k' +
+                    ' -maxrate '+ vbitrate + 'k' +
+                    ' -payload_type 99' +
+                    ' -ssrc ' + videoSsrc +
+                    ' -f rtp' +
+                    ' -srtp_out_suite AES_CM_128_HMAC_SHA1_80' +
+                    ' -srtp_out_params ' + videoKey.toString('base64') +
+                    ' srtp://' + targetAddress + ':' + targetVideoPort +
+                    '?rtcpport=' + targetVideoPort +
+                    '&localrtcpport=' + targetVideoPort +
+                    '&pkt_size=' + packetsize;
+
+                    // Audio
+                    ffmpegCommand+= ' -map 0:0' +
+                    ' -acodec ' + acodec +
+                    ' -profile:a aac_eld' +
+                    ' -flags +global_header' +
+                    ' -f null' +
+                    ' -ar ' + asamplerate + 'k' +
+                    ' -b:a ' + abitrate + 'k' +
+                    ' -bufsize ' + abitrate + 'k' +
+                    ' -ac 1' +
+                    ' -payload_type 110' +
+                    ' -ssrc ' + audioSsrc +
+                    ' -f rtp' +
+                    ' -srtp_out_suite AES_CM_128_HMAC_SHA1_80' +
+                    ' -srtp_out_params ' + audioKey.toString('base64') +
+                    ' srtp://' + targetAddress + ':' + targetAudioPort +
+                    '?rtcpport=' + targetAudioPort +
+                    '&localrtcpport=' + targetAudioPort +
+                    '&pkt_size=' + packetsize;
+
+                    let ffmpeg = spawn(this.videoProcessor, ffmpegCommand.split(' '), {env: process.env});
+                    debugFFmpeg("Start streaming video from " + this.device.deviceName + " with " + width + "x" + height + "@" + vbitrate + "kBit");
+                    debugFFmpeg("ffmpeg " + ffmpegCommand);
+
+                    // Always setup hook on stderr.
+                    // Without this streaming stops within one to two minutes.
+                    ffmpeg.stderr.on('data', function(data) {
+                        // Do not log to the console if debugging is turned off
+                        debugFFmpeg(data.toString());
+                    });
+
+                    let self = this;
+                    ffmpeg.on('error', function(error){
+                        debugFFmpeg("An error occurs while making stream request");
+                        debugFFmpeg(error);
+                    });
+
+                    ffmpeg.on('close', (code) => {
+                        if(code == null || code == 0 || code == 255){
+                            debugFFmpeg("Stopped streaming with code %i",code);
+                        } else {
+                            debugFFmpeg("ERROR: FFmpeg exited with code " + code);
+                            for(var i=0; i < self.streamControllers.length; i++){
+                                var controller = self.streamControllers[i];
+                                if(controller.sessionIdentifier === sessionID){
+                                    controller.forceStop();
+                                }
+                            }
+                        }
+                    });
+
+                    // Add to ongoing sessions now that it's been started
+                    this.ongoingSessions[sessionIdentifier] = ffmpeg;
+                }
+                // Remove from pending sessions
+                delete this.pendingSessions[sessionIdentifier];
+            } else if (requestType == "stop") {
+                var ffmpegProcess = this.ongoingSessions[sessionIdentifier];
+                if (ffmpegProcess) {
+                    ffmpegProcess.kill('SIGTERM');
+                }
+            }
+        }
+    }
+
+    _createStreamControllers(numberOfStreams, options) {
+        let self = this;
+        for (var i = 0; i < numberOfStreams; i++) {
+            var streamController = new StreamController(i, options, self);
+
+            self.services.push(streamController.service);
+            self.streamControllers.push(streamController);
+        }
+    }
+}
+
+module.exports = ArloCameraSource;

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Live video streaming functionality requires transcoding of the video and audio s
 - `videoProcessor`: The video processor used to perform transcoding. Defaults to `ffmpeg`. An alternate executable maybe used, however it needs to conform to ffmpeg parameters.
 - `videoDecoder`: The video codec used to decode the incoming h264 stream from the Arlo server. Defaults to no value, meaning the default h.264 software decoder (`libx264`) will typically be used.
 - `videoEncoder`: The video codec used to encode the outgoing h264 stream to the iOS client device. Defaults to `libx264`.
-- `audioEncoder`: The audio codec that will be used to decode/encode the audio stream. HomeKit requires either an Opus or AAC-ELD format audio stream. Defaults to the `libfdk_aac` codec.
+- `audioEncoder`: The audio codec that will be used to decode/encode the audio stream. HomeKit requires either an Opus or AAC-ELD format audio stream. Defaults to the `libopus` codec, and currently Homebridge-Arlo tells HomeKit it only supports the Opus audio type.
 - `packetsize`: The packet sized to be used. Defaults to 1316. Use smaller multiples of 188 to possibly improve performance (376, 564, etc)
 - `maxBitrate`: The maximum bitrate of the encoded stream in kbit/s, the default is 300.
+- `additionalVideoCommands`: Any video-specific additional flags or commands to pass to the ffmpeg executable.
+- `additionalAudioCommands`: Any audio-specific additional flags or commands to pass to the ffmpeg executable.
 
 ### Streaming with a Raspberry Pi 3
 
@@ -125,7 +127,8 @@ cd FFmpeg
 # Build ffmpeg
 sudo make -j4
 
-# Install ffmpeg, and use checkinstall to build a self-contained deb file that can be easily backed up for later use or reinstallation. Fill in all information requested by checkinstall.
+# Install ffmpeg, and use checkinstall to build a self-contained deb file that can be easily
+# backed up for later use or reinstallation. Fill in all information requested by checkinstall.
 sudo checkinstall
 
 # Lock the custom ffmpeg package so it isn't replaced accidentally
@@ -135,6 +138,8 @@ echo "ffmpeg hold" | sudo dpkg --set-selections
 Thanks to KhaosT for the base ffmpeg implementation and setup instructions in [homebridge-camera-ffmpeg](https://github.com/KhaosT/homebridge-camera-ffmpeg) and the [Maniacland Blog](https://maniaclander.blogspot.com/2017/08/ffmpeg-with-pi-hardware-acceleration.html)/[locutusofborg780](https://www.reddit.com/r/raspberry_pi/comments/5677qw/hardware_accelerated_x264_encoding_with_ffmpeg/) for FFmpeg configuration instructions.
 
 ### Sample Configuration with Optional Parameters
+
+This sample configuration specifies that for streaming transcoding, ffmpeg should use the `h264_mmal` and `h264_omx` hardware decoders/encoders for the video stream.
 
 ```javascript
 "platforms": [

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ class ArloPlatform {
 
         this.config = config;
         this.api = api;
+        if (!api || api.version < 2.1) { throw new Error('Unexpected API version (less than 2.1)') }
         this.accessories = {};
         this.log = log;
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Arlo = require('node-arlo');
+const debug = require('debug')('Homebridge-Arlo');
 const crypto = require('crypto');
 const ip = require('ip');
 const spawn = require('child_process').spawn;
@@ -505,6 +506,7 @@ class ArloCameraSource extends EventEmitter {
         }
 
         this._createStreamControllers(options);
+        debug('Generated Camera Controller');
     }
 
     handleCloseConnection(connectionID) {
@@ -514,6 +516,7 @@ class ArloCameraSource extends EventEmitter {
     }
 
     handleSnapshotRequest(request, callback) {
+        debug('Snapshot requested');
         let now = Date.now();
 
         if (this.lastSnapshot && now < this.lastSnapshot + 300000) {
@@ -545,7 +548,7 @@ class ArloCameraSource extends EventEmitter {
     }
 
     prepareStream(request, callback) {
-        this.log("prepareStream");
+        debug('Prepare stream request');
 
         /*
         this.device.getStream(function(error, data, body) {
@@ -634,7 +637,7 @@ class ArloCameraSource extends EventEmitter {
     }
 
     handleStreamRequest(request) {
-        this.log("handleStreamRequest");
+        debug('Handle stream request');
 
         var sessionID = request["sessionID"];
         var requestType = request["type"];

--- a/index.js
+++ b/index.js
@@ -61,8 +61,9 @@ class ArloPlatform {
         else if (deviceType === Arlo.CAMERA) {
             this.log("Found: Camera - %s [%s]", deviceName, device.id);
 
-            let accessory = new PlatformAccessory(device.id, UUIDGen.generate(device.id), Accessory.Categories.CAMERA);
+            let accessory = new PlatformAccessory(deviceName, UUIDGen.generate(device.id), Accessory.Categories.CAMERA);
 
+            
             let service = accessory.getService(Service.AccessoryInformation);
 
             service.setCharacteristic(Characteristic.Manufacturer, "Arlo")

--- a/index.js
+++ b/index.js
@@ -555,9 +555,10 @@ class ArloCameraSource extends EventEmitter {
             this.log(body);
             callback();
         }.bind(this));
-        */
+        var self = this;
 
         this.device.getStream(function (streamURL) {
+            debug('Preparing stream for URL: %s',streamURL);
 
             var sessionInfo = {};
             let sessionID = request["sessionID"];
@@ -630,7 +631,8 @@ class ArloCameraSource extends EventEmitter {
             }
 
             response["address"] = addressResp;
-            this.pendingSessions[UUIDGen.unparse(sessionID)] = sessionInfo;
+
+            self.pendingSessions[UUIDGen.unparse(sessionID)] = sessionInfo;
 
             callback(response);
         });

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const Arlo = require('node-arlo');
 const debug = require('debug')('Homebridge-Arlo');
+const debugFFmpeg = require('debug')('ffmpeg');
 const crypto = require('crypto');
 const ip = require('ip');
 const spawn = require('child_process').spawn;
@@ -550,11 +551,6 @@ class ArloCameraSource extends EventEmitter {
     prepareStream(request, callback) {
         debug('Prepare stream request');
 
-        /*
-        this.device.getStream(function(error, data, body) {
-            this.log(body);
-            callback();
-        }.bind(this));
         var self = this;
 
         this.device.getStream(function (streamURL) {
@@ -733,30 +729,27 @@ class ArloCameraSource extends EventEmitter {
                     }
 
                     let ffmpeg = spawn(this.videoProcessor, ffmpegCommand.split(' '), {env: process.env});
-                    this.log("Start streaming video from " + this.name + " with " + width + "x" + height + "@" + vbitrate + "kBit");
-                    if(this.debug){
-                        console.log("ffmpeg " + ffmpegCommand);
-                    }
+                    debugFFmpeg("Start streaming video from " + this.device.deviceName + " with " + width + "x" + height + "@" + vbitrate + "kBit");
+                    debugFFmpeg("ffmpeg " + ffmpegCommand);
 
                     // Always setup hook on stderr.
                     // Without this streaming stops within one to two minutes.
                     ffmpeg.stderr.on('data', function(data) {
                         // Do not log to the console if debugging is turned off
-                        if(this.debug){
-                            console.log(data.toString());
-                        }
+                        debugFFmpeg(data.toString());
                     });
 
                     let self = this;
                     ffmpeg.on('error', function(error){
-                        self.log("An error occurs while making stream request");
-                        self.debug ? self.log(error) : null;
+                        debugFFmpeg("An error occurs while making stream request");
+                        debugFFmpeg(error);
                     });
+
                     ffmpeg.on('close', (code) => {
                         if(code == null || code == 0 || code == 255){
-                            self.log("Stopped streaming");
+                            debugFFmpeg("Stopped streaming");
                         } else {
-                            self.log("ERROR: FFmpeg exited with code " + code);
+                            debugFFmpeg("ERROR: FFmpeg exited with code " + code);
                             for(var i=0; i < self.streamControllers.length; i++){
                                 var controller = self.streamControllers[i];
                                 if(controller.sessionIdentifier === sessionID){

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ class ArloPlatform {
             accessory.addService(Service.MotionSensor, deviceName);
 
             service = accessory.addService(Service.CameraControl, deviceName);
+            service = accessory.addService(Service.Microphone, deviceName);
 
             service.addCharacteristic(Characteristic.NightVision);
             service.addCharacteristic(Characteristic.ImageMirroring);
@@ -502,7 +503,6 @@ class ArloCameraSource extends EventEmitter {
             }
         }
 
-        this._createCameraControlService();
         this._createStreamControllers(options);
     }
 
@@ -780,15 +780,6 @@ class ArloCameraSource extends EventEmitter {
 
         this.services.push(streamController.service);
         this.streamControllers.push(streamController);
-    }
-
-    _createCameraControlService() {
-        var controlService = new Service.CameraControl();
-        this.services.push(controlService);
-        if(this.audio){
-            var microphoneService = new Service.Microphone();
-        }
-        this.services.push(microphoneService);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const Arlo = require('node-arlo');
 const crypto = require('crypto');
 const ip = require('ip');
+const spawn = require('child_process').spawn;
 
 const EventEmitter = require('events').EventEmitter;
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
         "arlo"
     ],
     "dependencies": {
+        "debug": "3.x",
+        "ip": "1.x",
         "node-arlo": ">=0.0.7"
     }
 }


### PR DESCRIPTION
This PR adds the functionality to stream from Arlo cameras (and probably Arlo Q, although I don't have one to try it), using `ffmpeg` to transcode the video and audio streams as necessary. This PR requires the [companion PR on node-arlo](https://github.com/devbobo/node-arlo/pull/5) in order to get the stream URL from the Arlo servers.

The code in this PR is _heavily_ based on [homebridge-camera-ffmpeg](https://github.com/KhaosT/homebridge-camera-ffmpeg), so I broke a lot of that functionality out into a different file that retains the Apache 2.0 license.

I've tested this myself with decent success on a Raspberry Pi 3 and `ffmpeg` custom compiled to include the codecs necessary. The downside is I don't think the default `ffmpeg` included with Rapsbian has those codecs enabled, so custom compilation is pretty much required.

Strangely, video transcoding is super smooth (and actually unnecessary if a 1280x720 video is requested) but the audio is completely garbled when using the `libfdk_aac` codec. This might be because Arlo provides an audio stream in the `AAC-LC` format but HomeKit requires it to be in the `AAC-ELD` format, and per some `ffmpeg` documentation I found AAC-to-AAC transcoding might suffer a lot of degradation.

I'm recompiling my `ffmpeg` as I type this with `libopus`, the other HomeKit-accepted audio stream format. If that's more successful, I might update this PR to switch that to the default audio codec.