### PR TITLE
Update `ffmpeg`

### DIFF
--- a/ArloCameraSource.js
+++ b/ArloCameraSource.js
@@ -210,6 +210,7 @@ const Arlo = require('node-arlo');
 const crypto = require('crypto');
 const ip = require('ip');
 const spawn = require('child_process').spawn;
+const pathToFfmpeg = require('ffmpeg-for-homebridge');
 
 let StreamController, UUIDGen;
 
@@ -229,7 +230,7 @@ class ArloCameraSource extends EventEmitter {
         this.streamControllers = [];
         this.lastSnapshot = null;
 
-        this.videoProcessor = config.videoProcessor || 'ffmpeg';
+        this.videoProcessor = config.videoProcessor || pathToFfmpeg || 'ffmpeg';
         this.videoDecoder = config.videoDecoder || '';
         this.videoEncoder = config.videoEncoder || 'libx264';
         this.audioCodec = config.audioEncoder || 'libopus';

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,141 @@
+{
+    "pluginAlias": "Arlo",
+    "pluginType": "platform",
+    "singular": true,
+    "headerDisplay": "Test.",
+    "footerDisplay": "Test.",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "default": "Arlo",
+          "required": true
+        },
+        "email": {
+          "type": "string",
+          "title": "E-mail",
+          "placeholder": "email@arlo.com",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "placeholder": "Your Arlo Password",
+          "required": true
+        },
+        "interval": {
+          "type": "integer",
+          "title": "Interval",
+          "placeholder": "6000",
+          "required": false
+        },
+        "stay_arm": {
+          "type": "integer",
+          "title": "Stay Arm",
+          "placeholder": "modeX",
+          "required": false,
+          "description": "The modeX label for the custom mode created in Arlo for the home or stay state."
+        },
+        "night_arm": {
+          "type": "integer",
+          "title": "Night Arm",
+          "placeholder": "modeX",
+          "required": false,
+          "description": "The modeX label for the custom mode created in Arlo for the night state."
+        },
+        "streaming": {
+          "type": "object",
+          "properties": {
+            "videoProcessor": {
+              "title": "Video Decoder",
+              "type": "string",
+              "required": false,
+              "placeholder": "ffmpeg",
+              "description": "Default: ffmpeg, The video processor used to perform transcoding. An alternate executable maybe used, however it needs to conform to ffmpeg parameters."
+            },
+            "videoDecoder": {
+              "title": "Video Decoder",
+              "type": "string",
+              "required": false,
+              "placeholder": "libx264",
+              "description": "Default: libx264, The video codec used to decode the incoming h264 stream from the Arlo server."
+            },
+            "videoEncoder": {
+              "title": "Video Encoder",
+              "type": "string",
+              "required": false,
+              "placeholder": "libx264",
+              "description": "Default: libx264, The video codec used to encode the outgoing h264 stream to the iOS client device."
+            },
+            "audioEncoder": {
+              "title": "Video Encoder",
+              "type": "string",
+              "required": false,
+              "placeholder": "libopus",
+              "description": "Default: libopus, The audio codec that will be used to decode/encode the audio stream. HomeKit requires either an Opus or AAC-ELD format audio stream."
+            },
+            "packetSize": {
+              "title": "Packet Size",
+              "type": "string",
+              "required": false,
+              "placeholder": "1316",
+              "description": " Default: 1316, The packet sized to be used. Use smaller multiples of 188 to possibly improve performance (376, 564, etc)."
+            },
+            "maxBitrate": {
+              "title": "Packet Size",
+              "type": "string",
+              "required": false,
+              "placeholder": "300",
+              "description": "Default: 300, The maximum bitrate of the encoded stream in kbit/s."
+            },
+            "additionalVideoCommands": {
+              "title": "Packet Size",
+              "type": "string",
+              "required": false,
+              "description": "Any video-specific additional flags or commands to pass to the ffmpeg executable."
+            },
+            "additionalAudioCommands": {
+              "title": "Packet Size",
+              "type": "string",
+              "required": false,
+              "description": "Any audio-specific additional flags or commands to pass to the ffmpeg executable."
+            }
+          }
+        }
+      }
+    },
+    "layout": [
+      "name",
+      "email",
+      "password",
+      {
+        "type": "fieldset",
+        "title": "Streaming Settings",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          "streaming.videoProcessor",
+          "streaming.videoDecoder",
+          "streaming.videoEncoder",
+          "streaming.audioEncoder",
+          "streaming.packetSize",
+          "streaming.maxBitrate",
+          "streaming.additionalVideoCommands",
+          "streaming.additionalAudioCommands"
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "Optional Settings",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          "interval",
+          "stay_arm",
+          "night_arm"
+        ]
+      }
+    ]
+  }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     ],
     "dependencies": {
         "debug": "3.x",
+        "ffmpeg-for-homebridge": "^0",
         "ip": "1.x",
         "node-arlo": ">=0.0.7"
     }


### PR DESCRIPTION
Add `ffmpeg-for-homebridge` - static `ffmpeg` binaries for Homebridge with support for audio (`libfdk-aac`) and hardware decoding (`h264_omx`).